### PR TITLE
Rename input parameter to `request-user-reviews`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: 'Add users as assignees on the PR'
     default: 'true'
     required: false
-  request-reviews:
+  request-user-reviews:
     description: 'Request PR reviews from component contributors'
     default: 'true'
     required: false


### PR DESCRIPTION
To fix #4 

`request-user-reviews` is the name used for the input parameter in the README file as well as `src/main.ts` file.

## Changes
- Rename `request-reviews` to `request-user-reviews`

